### PR TITLE
Replaced "Remove f4f" string with "Softblock"

### DIFF
--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -70,7 +70,7 @@
     <string name="destroy_mute">Cancel Mute</string>
     <string name="create_block">Block</string>
     <string name="destroy_block">Cancel Block</string>
-    <string name="destroy_follow_follower">Cancel f4f</string>
+    <string name="destroy_follow_follower">Softblock</string>
     <string name="save_image">Save this image</string>
     <string name="save_video">Save this video</string>
     <string name="error_occurred">Error occurred</string>


### PR DESCRIPTION
"Softblock" is a term that's more commonly used among Twitter users when you block/unblock a follower in order to remove them from your following list.